### PR TITLE
Transaction version field should be int32_t

### DIFF
--- a/src/serialize.c
+++ b/src/serialize.c
@@ -5,9 +5,6 @@
 
 #include "serialize.h"
 
-#include <stdint.h>
-#include <string.h>
-
 #include "btc/cstr.h"
 
 void ser_bytes(cstring* s, const void* p, size_t len)
@@ -120,6 +117,17 @@ btc_bool deser_u16(uint16_t* vo, struct const_buffer* buf)
         return false;
 
     *vo = le16toh(v);
+    return true;
+}
+
+btc_bool deser_i32(int32_t* vo, struct const_buffer* buf)
+{
+    int32_t v;
+
+    if (!deser_bytes(&v, buf, sizeof(v)))
+        return false;
+
+    *vo = le32toh(v);
     return true;
 }
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -40,7 +40,6 @@ extern void ser_bytes(cstring* s, const void* p, size_t len);
 extern void ser_u16(cstring* s, uint16_t v_);
 extern void ser_u32(cstring* s, uint32_t v_);
 extern void ser_u64(cstring* s, uint64_t v_);
-
 static inline void ser_u256(cstring* s, const unsigned char* v_)
 {
     ser_bytes(s, v_, 32);
@@ -67,6 +66,9 @@ extern btc_bool deser_bytes(void* po, struct const_buffer* buf, size_t len);
 extern btc_bool deser_u16(uint16_t* vo, struct const_buffer* buf);
 extern btc_bool deser_u32(uint32_t* vo, struct const_buffer* buf);
 extern btc_bool deser_u64(uint64_t* vo, struct const_buffer* buf);
+
+extern btc_bool deser_i32(int32_t* vo, struct const_buffer* buf);
+
 
 static inline btc_bool deser_u256(uint8_t* vo, struct const_buffer* buf)
 {

--- a/src/tx.c
+++ b/src/tx.c
@@ -159,7 +159,7 @@ int btc_tx_deserialize(const unsigned char* tx_serialized, size_t inlen, btc_tx*
     struct const_buffer buf = {tx_serialized, inlen};
 
     //tx needs to be initialized
-    deser_u32(&tx->version, &buf);
+    deser_i32(&tx->version, &buf);
     uint32_t vlen;
     if (!deser_varlen(&vlen, &buf))
         return false;

--- a/test/serialize_tests.c
+++ b/test/serialize_tests.c
@@ -86,4 +86,16 @@ void test_serialize()
     cstr_free(deser_test, true);
 
     cstr_free(s2, true);
+
+    struct const_buffer buf3 = {NULL, 0};
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    int32_t i32;
+
+    assert(deser_u16(&u16, &buf3) == false);
+    assert(deser_u32(&u32, &buf3) == false);
+    assert(deser_u64(&u64, &buf3) == false);
+    assert(deser_i32(&i32, &buf3) == false);
+
 }


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/blob/master/src/primitives/transaction.h#L194

The transaction version field is a signed integer, so I added serialization methods for int32_t (only), and updated the field. 