### PR TITLE
Block header support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ $(LIBSECP256K1): $(wildcard src/secp256k1/src/*) $(wildcard src/secp256k1/includ
 lib_LTLIBRARIES = libbtc.la
 include_HEADERS = include/btc/btc.h \
 	include/btc/tx.h \
+	include/btc/block.h \
 	include/btc/base58.h \
 	include/btc/bip32.h \
 	include/btc/ecc_key.h \
@@ -36,6 +37,7 @@ pkgconfig_DATA = libbtc.pc
 
 libbtc_la_SOURCES = \
 	src/sha2.c \
+	src/block.c \
 	src/utils.c \
 	src/base58.c \
 	src/ripemd160.c \
@@ -61,6 +63,7 @@ tests_SOURCES = \
 	test/utest.h \
 	test/unittester.c \
 	test/sha2_tests.c \
+	test/block_tests.c \
 	test/base58check_tests.c \
 	test/bip32_tests.c \
 	test/random_tests.c \

--- a/include/btc/block.h
+++ b/include/btc/block.h
@@ -1,0 +1,37 @@
+
+#ifndef LIBBTC_BLOCK_H
+#define LIBBTC_BLOCK_H
+
+
+#include "btc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <sys/types.h>
+#include "hash.h"
+#include "cstr.h"
+
+typedef struct btc_block_header_ {
+    int32_t version;
+    uint256 hashPrevBlock;
+    uint256 hashMerkleRoot;
+    uint32_t timestamp;
+    uint32_t bits;
+    uint32_t nonce;
+} btc_block_header;
+
+LIBBTC_API btc_block_header* btc_block_header_new();
+LIBBTC_API void btc_block_header_free(btc_block_header* header);
+LIBBTC_API int btc_block_header_deserialize(const unsigned char* header_serialized, size_t headerlen, btc_block_header* header);
+LIBBTC_API void btc_block_header_serialize(cstring* s, const btc_block_header* header);
+LIBBTC_API void btc_block_header_copy(btc_block_header* dest, const btc_block_header* src);
+LIBBTC_API btc_bool btc_block_header_hash(btc_block_header*header, uint8_t* hash);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //__LIBBTC_BLOCK_H__

--- a/src/block.c
+++ b/src/block.c
@@ -1,0 +1,113 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2016 Thomas Kerin
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+#include "btc/block.h"
+#include "serialize.h"
+#include "sha2.h"
+#include "utils.h"
+#include "../include/btc/block.h"
+
+btc_block_header* btc_block_header_new()
+{
+    btc_block_header* header;
+    header = calloc(1, sizeof(*header));
+
+    return header;
+}
+
+void btc_block_header_free(btc_block_header* header)
+{
+    if (!header)
+        return;
+
+    header->version = 1;
+    memset(&header->hashPrevBlock, 0, 32);
+    memset(&header->hashMerkleRoot, 0, 32);
+    header->bits = 0;
+    header->timestamp = 0;
+    header->nonce = 0;
+    free(header);
+
+}
+
+int btc_block_header_deserialize(const unsigned char* header_serialized, size_t headerilen, btc_block_header* header)
+{
+    struct const_buffer buf = {header_serialized, headerilen};
+
+    if (!deser_i32(&header->version, &buf))
+        return false;
+    if (!deser_u256(header->hashPrevBlock, &buf))
+        return false;
+    if (!deser_u256(header->hashMerkleRoot, &buf))
+        return false;
+    if (!deser_u32(&header->timestamp, &buf))
+        return false;
+    if (!deser_u32(&header->bits, &buf))
+        return false;
+    if (!deser_u32(&header->nonce, &buf))
+        return false;
+
+    return true;
+}
+
+void btc_block_header_serialize(cstring* s, const btc_block_header* header)
+{
+    ser_i32(s, header->version);
+    ser_u256(s, header->hashPrevBlock);
+    ser_u256(s, header->hashMerkleRoot);
+    ser_u32(s, header->timestamp);
+    ser_u32(s, header->bits);
+    ser_u32(s, header->nonce);
+}
+
+void btc_block_header_copy(btc_block_header* dest, const btc_block_header* src)
+{
+    dest->version = src->version;
+    memcpy(&dest->hashPrevBlock, &src->hashPrevBlock, sizeof(src->hashPrevBlock));
+    memcpy(&dest->hashMerkleRoot, &src->hashMerkleRoot, sizeof(src->hashMerkleRoot));
+    dest->timestamp = src->timestamp;
+    dest->bits = src->bits;
+    dest->nonce = src->nonce;
+}
+
+btc_bool btc_block_header_hash(btc_block_header* header, uint8_t* hash)
+{
+    cstring* s = cstr_new_sz(80);
+    btc_block_header_serialize(s, header);
+
+    sha256_Raw((const uint8_t*)s->str, s->len, hash);
+    sha256_Raw(hash, 32, hash);
+    cstr_free(s, true);
+
+    btc_bool ret = true;
+    return ret;
+}

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -5,9 +5,6 @@
 
 #include "serialize.h"
 
-#include <stdint.h>
-#include <string.h>
-
 #include "btc/cstr.h"
 
 void ser_bytes(cstring* s, const void* p, size_t len)
@@ -120,6 +117,17 @@ btc_bool deser_u16(uint16_t* vo, struct const_buffer* buf)
         return false;
 
     *vo = le16toh(v);
+    return true;
+}
+
+btc_bool deser_i32(int32_t* vo, struct const_buffer* buf)
+{
+    int32_t v;
+
+    if (!deser_bytes(&v, buf, sizeof(v)))
+        return false;
+
+    *vo = le32toh(v);
     return true;
 }
 

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -24,6 +24,12 @@ void ser_u32(cstring* s, uint32_t v_)
     cstr_append_buf(s, &v, sizeof(v));
 }
 
+void ser_i32(cstring* s, int32_t v_)
+{
+    int32_t v = htole32(v_);
+    cstr_append_buf(s, &v, sizeof(v));
+}
+
 void ser_u64(cstring* s, uint64_t v_)
 {
     uint64_t v = htole64(v_);

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -26,8 +26,7 @@ void ser_u32(cstring* s, uint32_t v_)
 
 void ser_i32(cstring* s, int32_t v_)
 {
-    int32_t v = htole32(v_);
-    cstr_append_buf(s, &v, sizeof(v));
+    ser_u32(s, (uint32_t) v_);
 }
 
 void ser_u64(cstring* s, uint64_t v_)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -40,7 +40,6 @@ extern void ser_bytes(cstring* s, const void* p, size_t len);
 extern void ser_u16(cstring* s, uint16_t v_);
 extern void ser_u32(cstring* s, uint32_t v_);
 extern void ser_u64(cstring* s, uint64_t v_);
-
 static inline void ser_u256(cstring* s, const unsigned char* v_)
 {
     ser_bytes(s, v_, 32);
@@ -67,6 +66,9 @@ extern btc_bool deser_bytes(void* po, struct const_buffer* buf, size_t len);
 extern btc_bool deser_u16(uint16_t* vo, struct const_buffer* buf);
 extern btc_bool deser_u32(uint32_t* vo, struct const_buffer* buf);
 extern btc_bool deser_u64(uint64_t* vo, struct const_buffer* buf);
+
+extern btc_bool deser_i32(int32_t* vo, struct const_buffer* buf);
+
 
 static inline btc_bool deser_u256(uint8_t* vo, struct const_buffer* buf)
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -39,6 +39,7 @@
 extern void ser_bytes(cstring* s, const void* p, size_t len);
 extern void ser_u16(cstring* s, uint16_t v_);
 extern void ser_u32(cstring* s, uint32_t v_);
+extern void ser_i32(cstring* s, int32_t v_);
 extern void ser_u64(cstring* s, uint64_t v_);
 static inline void ser_u256(cstring* s, const unsigned char* v_)
 {

--- a/src/tx.c
+++ b/src/tx.c
@@ -159,7 +159,7 @@ int btc_tx_deserialize(const unsigned char* tx_serialized, size_t inlen, btc_tx*
     struct const_buffer buf = {tx_serialized, inlen};
 
     //tx needs to be initialized
-    deser_u32(&tx->version, &buf);
+    deser_i32(&tx->version, &buf);
     uint32_t vlen;
     if (!deser_varlen(&vlen, &buf))
         return false;

--- a/src/tx.c
+++ b/src/tx.c
@@ -209,7 +209,7 @@ void btc_tx_out_serialize(cstring* s, const btc_tx_out* tx_out)
 
 void btc_tx_serialize(cstring* s, const btc_tx* tx)
 {
-    ser_u32(s, tx->version);
+    ser_i32(s, tx->version);
 
     ser_varlen(s, tx->vin ? tx->vin->len : 0);
 

--- a/test/block_tests.c
+++ b/test/block_tests.c
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (c) 2015 Jonas Schnelli                                  *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <btc/block.h>
+
+#include <btc/cstr.h>
+#include <btc/ecc_key.h>
+#include "utils.h"
+
+struct blockheadertest {
+    char hexheader[160];
+    char hexhash[64];
+};
+
+static const struct blockheadertest block_header_tests[] =
+        {
+                {"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c", "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"}
+        };
+
+void test_block_header()
+{
+    int outlen;
+    cstring* serialized = cstr_new_sz(80);
+    char hexbuf[160];
+    unsigned int i;
+    for (i = 0; i < (sizeof(block_header_tests) / sizeof(block_header_tests[0])); i++) {
+
+        const struct blockheadertest* test = &block_header_tests[i];
+        uint8_t header_data[80];
+        uint8_t hash_data[32];
+
+        utils_hex_to_bin(test->hexheader, header_data, 160, &outlen);
+        utils_hex_to_bin(test->hexhash, hash_data, 32, &outlen);
+
+        btc_block_header* header = btc_block_header_new();
+        btc_block_header_deserialize(header_data, 80, header);
+
+        // Check the copies are the same
+        btc_block_header* header_copy = btc_block_header_new();
+        btc_block_header_copy(header_copy, header);
+        assert(memcpy(header_copy, header, sizeof(header_copy)));
+
+        // Check the serialized form matches
+        btc_block_header_serialize(serialized, header);
+        utils_bin_to_hex((unsigned char*) serialized->str, serialized->len, hexbuf);
+        assert(memcmp(hexbuf, test->hexheader, 160) == 0);
+
+        // Check the block hash
+        uint8_t blockhash[32];
+        btc_block_header_hash(header, blockhash);
+
+        utils_bin_to_hex(blockhash, 32, hexbuf);
+        utils_reverse_hex(hexbuf, 64);
+        assert(memcmp(hexbuf, test->hexhash, 64) == 0);
+
+        btc_block_header_free(header);
+        btc_block_header_free(header_copy);
+    }
+    cstr_free(serialized, true);
+}

--- a/test/serialize_tests.c
+++ b/test/serialize_tests.c
@@ -86,4 +86,16 @@ void test_serialize()
     cstr_free(deser_test, true);
 
     cstr_free(s2, true);
+
+    struct const_buffer buf3 = {NULL, 0};
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    int32_t i32;
+
+    assert(deser_u16(&u16, &buf3) == false);
+    assert(deser_u32(&u32, &buf3) == false);
+    assert(deser_u64(&u64, &buf3) == false);
+    assert(deser_i32(&i32, &buf3) == false);
+
 }

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -735,6 +735,24 @@ void test_tx_sighash()
     }
 }
 
+
+void test_tx_negative_version()
+{
+    char txhex[] =   "ffffffff0100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0100e1f505000000000000000000";
+    int32_t versionGoal = -1;
+
+    uint8_t tx_data[sizeof(txhex) / 2];
+    int outlen;
+    utils_hex_to_bin(txhex, tx_data, strlen(txhex), &outlen);
+
+    btc_tx* tx = btc_tx_new();
+    btc_tx_deserialize(tx_data, sizeof(txhex) / 2, tx);
+    u_assert_int_eq(versionGoal, tx->version);
+
+    btc_tx_free(tx);
+}
+
+
 struct script_test {
     char script[32];
 };

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -40,6 +40,7 @@ extern void test_sha_512();
 extern void test_sha_hmac();
 extern void test_bitcoin_hash();
 extern void test_base58check();
+extern void test_block_header();
 extern void test_bip32();
 extern void test_ecc();
 extern void test_vector();
@@ -82,6 +83,7 @@ int main()
     u_run_test(test_serialize);
     u_run_test(test_tx_serialization);
     u_run_test(test_tx_sighash);
+    u_run_test(test_block_header);
     u_run_test(test_script_parse);
     u_run_test(test_script_op_codeseperator);
 

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -51,6 +51,7 @@ extern void test_aes();
 extern void test_serialize();
 extern void test_tx_serialization();
 extern void test_tx_sighash();
+extern void test_tx_negative_version();
 extern void test_script_parse();
 extern void test_script_op_codeseperator();
 extern void test_eckey();

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -83,6 +83,7 @@ int main()
     u_run_test(test_serialize);
     u_run_test(test_tx_serialization);
     u_run_test(test_tx_sighash);
+    u_run_test(test_tx_negative_version);
     u_run_test(test_block_header);
     u_run_test(test_script_parse);
     u_run_test(test_script_op_codeseperator);


### PR DESCRIPTION
Makes use of #32 

Adds basic support for block headers (serialization and hashing)