### PR TITLE
Fix buffer size for utils_bin_to_hex in block_test.c

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -29,7 +29,7 @@
 #include <string.h>
 
 
-#include "btc/block.h"
+#include <btc/block.h>
 
 #include <btc/serialize.h>
 #include <btc/sha2.h>

--- a/test/block_tests.c
+++ b/test/block_tests.c
@@ -33,7 +33,7 @@ static const struct blockheadertest block_header_tests[] =
 void test_block_header()
 {
     int outlen;
-    char hexbuf[160];
+    char hexbuf[161];
     unsigned int i;
     for (i = 0; i < (sizeof(block_header_tests) / sizeof(block_header_tests[0])); i++) {
         cstring* serialized = cstr_new_sz(80);


### PR DESCRIPTION
Introduced in #37
Reported in #49 (fixes #49)