### PR TITLE
Fix 3 compile warnings. Also fix test potential false positives due to cast.

### DIFF
--- a/src/logdb/test/logdb_tests.c
+++ b/src/logdb/test/logdb_tests.c
@@ -42,8 +42,8 @@ void test_logdb(logdb_log_db* (*new_func)())
     char hexrev[98];
     int outlenrev;
     long fsize;
-    char *buf;
-    char *wrk_buf;
+    uint8_t *buf;
+    uint8_t *wrk_buf;
     FILE *f;
     unsigned int i;
     char bufs[300][65];
@@ -120,7 +120,7 @@ void test_logdb(logdb_log_db* (*new_func)())
     u_assert_int_eq(memcmp(value_test->str, value->str, value->len), 0);
 
     value_test = logdb_find(db, key2);
-    u_assert_int_eq((int)value_test, 0); /* should be null */
+    u_assert_is_null(value_test);
 
     /* overwrite a key */
     logdb_append(db, NULL, key, value0);

--- a/test/utest.h
+++ b/test/utest.h
@@ -195,6 +195,34 @@
         } while (0);                                                     \
     }
 
+#define u_assert_is_null(R)                                              \
+    {                                                                    \
+        const void* r_ = (R);                                            \
+        do {                                                             \
+            if (r_) {                                                    \
+                printf("FAILED - %s() - Line %d\n", __func__, __LINE__); \
+                printf("\tExpect: \tNULL\n");                            \
+                printf("\tReceive:\t%p\n", r_);                          \
+                U_TESTS_FAIL++;                                          \
+                return;                                                  \
+            };                                                           \
+        } while (0);                                                     \
+    }
+
+#define u_assert_not_null(R)                                             \
+    {                                                                    \
+        const void* r_ = (R);                                            \
+        do {                                                             \
+            if (!r_) {                                                   \
+                printf("FAILED - %s() - Line %d\n", __func__, __LINE__); \
+                printf("\tExpect: \tnot NULL\n");                        \
+                printf("\tReceive:\tNULL\n", r_);                        \
+                U_TESTS_FAIL++;                                          \
+                return;                                                  \
+            };                                                           \
+        } while (0);                                                     \
+    }
+
 extern int U_TESTS_RUN;
 extern int U_TESTS_FAIL;
 


### PR DESCRIPTION
This is to fix the only 3 warnings I get with my compiler. (GCC 6.3.1)
The type of *buf and *wrk_buf is changed from char to uint8_t. This allows the tests to assign values between 0 and 255 and avoid warnings.  
An alternative could have been to leave their type to char and assign the value that results after an unsigned char has been cast to a signed char. So -0x78 instead of 0x88, and -0x01 instead of 0xFF. But I think just dealing with positive numbers is less confusing.

The third warning is caused by a pointer being cast to an int of different size. This can be fixed by casting to uintptr_t, which is guaranteed to have the same size of the pointer.
The test function called has also been changed from u_assert_int_eq() to u_assert_uint32_eq(). Despite its name, the former uses uint64_t to compare the result (I think it should be renamed !).  
This fixes the test potentially producing false positives with any 64bit value that is multiple of 2^32, as they overflow to 0 when cast to 32bit int.
