### PR TITLE
Check return value of btc_hd_generate_key() and add tests

### DIFF
--- a/src/commontools.c
+++ b/src/commontools.c
@@ -145,7 +145,8 @@ btc_bool hd_derive(const btc_chainparams* chain, const char* masterkey, const ch
     bool pubckd = !btc_hdnode_has_privkey(&node);
 
     //derive child key, use pubckd or privckd
-    btc_hd_generate_key(&nodenew, keypath, pubckd ? node.public_key : node.private_key, node.chain_code, pubckd);
+    if (!btc_hd_generate_key(&nodenew, keypath, pubckd ? node.public_key : node.private_key, node.chain_code, pubckd))
+        return false;
 
     if (pubckd)
         btc_hdnode_serialize_public(&nodenew, chain, extkeyout, extkeyout_size);

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -44,12 +44,19 @@ void test_tool()
 
     size_t extoutsize = 200;
     char extout[extoutsize];
-    u_assert_int_eq(hd_derive(&btc_chainparams_main, "xprv9s21ZrQH143K2JF8RafpqtKiTbsbaxEeUaMnNHsm5o6wCW3z8ySyH4UxFVSfZ8n7ESu7fgir8imbZKLYVBxFPND1pniTZ81vKfd45EHKX73", "m/1", extout, extoutsize), true);
+    const char *privkey = "xprv9s21ZrQH143K2JF8RafpqtKiTbsbaxEeUaMnNHsm5o6wCW3z8ySyH4UxFVSfZ8n7ESu7fgir8imbZKLYVBxFPND1pniTZ81vKfd45EHKX73";
+
+    u_assert_int_eq(hd_derive(&btc_chainparams_main, privkey, "m/1", extout, extoutsize), true);
     u_assert_str_eq(extout, "xprv9tzRNW1ZnrURGVu66TgodMCdZfYms8dVapp4q24RswKY7hChXwrdnbyEFpfz26yVJh5h4zgBWiJ2nD8Qj3oGjjVNtyTFZFUrWQiYwwAfYdg");
 
-    u_assert_int_eq(hd_derive(&btc_chainparams_main, "xprv9s21ZrQH143K2JF8RafpqtKiTbsbaxEeUaMnNHsm5o6wCW3z8ySyH4UxFVSfZ8n7ESu7fgir8imbZKLYVBxFPND1pniTZ81vKfd45EHKX73", "m/1'", extout, extoutsize), true);
+    u_assert_int_eq(hd_derive(&btc_chainparams_main, privkey, "m/1'", extout, extoutsize), true);
     u_assert_str_eq(extout, "xprv9tzRNW1i8X1PSWBU8w1T7f8xCejSahmGsBLXi2XUqJPF7gLpn99mnuUK9jUKUP9hZbi5bbMCcHKi7MceLJ2ya3ArinuB3rDgcUnSzks1iWk");
 
     u_assert_int_eq(hd_derive(&btc_chainparams_main, "xpub661MyMwAqRbcEnKbXcCqD2GT1di5zQxVqoHPAgHNe8dv5JP8gWmDproS6kFHJnLZd23tWevhdn4urGJ6b264DfTGKr8zjmYDjyDTi9U7iyT", "m/1", extout, extoutsize), true);
-    
+
+    u_assert_int_eq(hd_derive(&btc_chainparams_main, privkey, "m/", extout, extoutsize), true);
+    u_assert_str_eq(extout, privkey);
+
+    u_assert_int_eq(hd_derive(&btc_chainparams_main, privkey, "m", extout, extoutsize), false);
+    u_assert_int_eq(hd_derive(&btc_chainparams_main, privkey, "n/1", extout, extoutsize), false);
 }

--- a/tooltests.py
+++ b/tooltests.py
@@ -23,7 +23,10 @@ commands.append(["-c pubfrompriv -p L15mEfW7s13utgsTrziK52z6HC1jEZbp3R9", 1]) #i
 commands.append(["-c addrfrompub -p 02b905509e4c9bd9b2fc87c95a6e6897f70ee9fd8bd2f1d9dc9a270b62ec11f47e", 1])
 commands.append(["-c addrfrompub -k 02b905509e4c9bd9b2fc87c95a6e6897f70ee9fd8bd2f1d9dc9a270b62ec11f47e", 0])
 commands.append(["-c hdgenmaster", 0])
-commands.append(["-c hdderive -p xpub6MR9tbm8V5pGFTQ9hTATxd4kPgdKKqU75ED8s3rddrSknLHgZy1H4Wh596jgoYNH7WNcKEVM1wfKD2pTSdj5Hm7CMJwwyRjHYPQCT2LJXwm -m m/100h/10h/100/10", 0])
+commands.append(["-c hdderive -p xpub6MR9tbm8V5pGFTQ9hTATxd4kPgdKKqU75ED8s3rddrSknLHgZy1H4Wh596jgoYNH7WNcKEVM1wfKD2pTSdj5Hm7CMJwwyRjHYPQCT2LJXwm -m m/100h/10h/100/10", 1]) #hardened keypath with pubkey
+commands.append(["-c hdderive -p xprv9s21ZrQH143K3jC7xiaZ4EWrJdwJgtrEBmbVBpnoLNo91RCkdzkviG2GjgmN7xaDSDgPihJWu7JRGVcLUSoJdW8fHhGSpjQGUMoU2e8KjBY -m m/100h/10h/100/10", 0])
+commands.append(["-c hdderive -p xprv9s21ZrQH143K3jC7xiaZ4EWrJdwJgtrEBmbVBpnoLNo91RCkdzkviG2GjgmN7xaDSDgPihJWu7JRGVcLUSoJdW8fHhGSpjQGUMoU2e8KjBY -m n/100h/10h/100/10", 1]) #wrong keypath prefix
+commands.append(["-c hdderive -p xpub6MR9tbm8V5pGFTQ9hTATxd4kPgdKKqU75ED8s3rddrSknLHgZy1H4Wh596jgoYNH7WNcKEVM1wfKD2pTSdj5Hm7CMJwwyRjHYPQCT2LJXwm -m m/100/10/100/10", 0])
 commands.append(["-c hdderive", 1]) #missing key
 commands.append(["-c hdderive -p xpub6MR9tbm8V5pGFTQ9hTATxd4kPgdKKqU75ED8s3rddrSknLHgZy1H4Wh596jgoYNH7WNcKEVM1wfKD2pTSdj5Hm7CMJwwyRjHYPQCT2LJXwm", 1]) #missing keypath
 


### PR DESCRIPTION
The function hd_derive() calls btc_hd_generate_key(), but it doesn't check whether it succeeds or not.  
This has the effect that if for example the keypath is mistyped to "n/0/0", bitcointool returns at first glance valid output, but the "depth" is 128 instead of 2.  
Moreover, at every invocation with the same inputs(privkey/keypath), it returns different outputs!  
This is extremely dangerous and should really be fixed as soon as possible.  
I also added a few tests to check for this behaviour.