### PR TITLE
Added some arguments checks for bitcointool

### DIFF
--- a/src/tools/bitcointool.c
+++ b/src/tools/bitcointool.c
@@ -127,12 +127,15 @@ int main(int argc, char* argv[])
     /* start ECC context */
     btc_ecc_start();
 
+    const char *pkey_error = "Missing extended key (use -p)";
 
     if (strcmp(cmd, "pubfrompriv") == 0) {
         /* output compressed hex pubkey from hex privkey */
 
         size_t sizeout = 128;
         char pubkey_hex[sizeout];
+        if (!pkey)
+            return showError(pkey_error);
         if (!pubkey_from_privatekey(chain, pkey, pubkey_hex, &sizeout))
             return showError("Operation failed");
 
@@ -155,6 +158,8 @@ int main(int argc, char* argv[])
 
         size_t sizeout = 128;
         char address[sizeout];
+        if (!pubkey)
+            return showError("Missing public key (use -k)");
         if (!address_from_pubkey(chain, pubkey, address))
             return showError("Operation failed, invalid pubkey");
         printf("p2pkh address: %s\n", address);
@@ -181,12 +186,12 @@ int main(int argc, char* argv[])
         memset(masterkey, 0, strlen(masterkey));
     } else if (strcmp(cmd, "hdprintkey") == 0) {
         if (!pkey)
-            return showError("Missing extended key (use -p)");
+            return showError(pkey_error);
         if (!hd_print_node(chain, pkey))
             return showError("Failed. Probably invalid extended key.\n");
     } else if (strcmp(cmd, "hdderive") == 0) {
         if (!pkey)
-            return showError("Missing extended key (use -p)");
+            return showError(pkey_error);
         if (!keypath)
             return showError("Missing keypath (use -m)");
         size_t sizeout = 128;

--- a/tooltests.py
+++ b/tooltests.py
@@ -19,6 +19,7 @@ commands.append(["-c hdprintkey -p xpub6MR9tbm8V5pGFTQ9hTATxd4kPgdKKqU75ED8s3rdd
 commands.append(["-c hdprintkey -p tprv8ZgxMBicQKsPegfnEE6sgR64tuPn72fX965MeazaJC72Sfi5JfqLrCnQmA9vTJTCxfDpiq2jWBSLc8L2Uy497ij5iT4KDvXYZRWxCNWPugm", 1])
 commands.append(["-c hdprintkey -p tprv8ZgxMBicQKsPegfnEE6sgR64tuPn72fX965MeazaJC72Sfi5JfqLrCnQmA9vTJTCxfDpiq2jWBSLc8L2Uy497ij5iT4KDvXYZRWxCNWPugm --testnet", 0])
 commands.append(["-c pubfrompriv -p L15mEfW7s13utgsTrziK52z6HC1jEZbp3R9ma7qPfwCphhtJFmjp", 0]) #successfull WIF to pub
+commands.append(["-c pubfrompriv", 1]) #missing required argument
 commands.append(["-c pubfrompriv -p L15mEfW7s13utgsTrziK52z6HC1jEZbp3R9", 1]) #invalid WIF key
 commands.append(["-c addrfrompub -p 02b905509e4c9bd9b2fc87c95a6e6897f70ee9fd8bd2f1d9dc9a270b62ec11f47e", 1])
 commands.append(["-c addrfrompub -k 02b905509e4c9bd9b2fc87c95a6e6897f70ee9fd8bd2f1d9dc9a270b62ec11f47e", 0])


### PR DESCRIPTION
Additional checks are added for bitcointool arguments.  
One check avoids a segmentation fault with the command "./bitcointool -c pubfrompriv".  
Another check causes the more useful message "Missing public key (use -k)" rather than "Error: Operation failed, invalid pubkey".