### PR TITLE
Added executables to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ test-suite.log
 *.so
 *.a
 !.gitignore
+bitcointool
+bitcoin-send-tx
 
 Makefile
 configure


### PR DESCRIPTION
Git is very annoying to use without this. I think it's also good practice.