### PR TITLE
Fix bitcoin-send-tx on arm CPUs

### DIFF
--- a/src/tools/bitcoin-send-tx.c
+++ b/src/tools/bitcoin-send-tx.c
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
 {
     int ret = 0;
     int long_index = 0;
-    char opt = 0;
+    int opt = 0;
     char* data = 0;
     char* ips = 0;
     int debug = 0;


### PR DESCRIPTION
bitcoin-send-tx is currently not able to run on some arm CPU platforms.  
This is because getopt_long_only() returns an int value that can be -1, and this value is assigned to the the "char opt" variable.  
The C standard doesn't guarantee whether the char type is signed or unsigned, and it's machine-dependent.  
On Intel platforms char is signed, and everything works fine, but on systems like my rpi2, char is unsigned. So on these platforms the "!= -1" condition will always be true, causing the issue.  
The tooltests.py tests are actually catching this problem, but travis-ci unfortunately seems to be running only on an Intel system.  
The fix is simple: just change char to int, which is guaranteed by the C standard to be able to take negative values.