### PR TITLE
add some additional files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ test-suite.log
 !.gitignore
 bitcointool
 bitcoin-send-tx
+bitcoin-spv
+bitcoin-txref
 
 Makefile
 configure
@@ -16,6 +18,7 @@ aclocal.m4
 autom4te.cache/
 config.log
 config.status
+*.db
 *.tar.gz
 *.la
 libtool


### PR DESCRIPTION
Thank you for this great resource, it's been instrumental in helping me understand the protocol. After building libbtc and running `bitcoin-spv -t scan` I get some junk according to `git status`:
 * The bitcoin-spv and bitcoin-txref targets aren't ignored
 * bitcoin-spv creates files named headers.db and wallet.db that aren't ignored