### PR TITLE
[WIP] Add support for simple tx signing

### DIFF
--- a/include/btc/cstr.h
+++ b/include/btc/cstr.h
@@ -45,7 +45,7 @@ typedef struct cstring {
 LIBBTC_API cstring* cstr_new(const char* init_str);
 LIBBTC_API cstring* cstr_new_sz(size_t sz);
 LIBBTC_API cstring* cstr_new_buf(const void* buf, size_t sz);
-LIBBTC_API cstring* cstr_new_cstr(cstring* copy_str);
+LIBBTC_API cstring* cstr_new_cstr(const cstring* copy_str);
 LIBBTC_API void cstr_free(cstring* s, int free_buf);
 
 LIBBTC_API int cstr_equal(const cstring* a, const cstring* b);

--- a/include/btc/ecc_key.h
+++ b/include/btc/ecc_key.h
@@ -32,6 +32,7 @@ extern "C" {
 #endif
 
 #include "btc.h"
+#include "chainparams.h"
 
 #include <stddef.h>
 
@@ -49,6 +50,10 @@ LIBBTC_API btc_bool btc_privkey_is_valid(btc_key* privkey);
 LIBBTC_API void btc_privkey_cleanse(btc_key* privkey);
 LIBBTC_API void btc_privkey_gen(btc_key* privkey);
 LIBBTC_API btc_bool btc_privkey_verify_pubkey(btc_key* privkey, btc_pubkey* pubkey);
+
+// form a WIF encoded string from the given pubkey, make sure privkey_wif is large enough and strsize_inout contains the size of the buffer
+LIBBTC_API void btc_privkey_encode_wif(const btc_key* privkey, const btc_chainparams* chain, char *privkey_wif, size_t *strsize_inout);
+LIBBTC_API btc_bool btc_privkey_decode_wif(const char *privkey_wif, const btc_chainparams* chain, btc_key* privkey);
 
 LIBBTC_API void btc_pubkey_init(btc_pubkey* pubkey);
 LIBBTC_API btc_bool btc_pubkey_is_valid(btc_pubkey* pubkey);

--- a/include/btc/ecc_key.h
+++ b/include/btc/ecc_key.h
@@ -80,6 +80,10 @@ LIBBTC_API btc_bool btc_key_sign_recover_pubkey(const unsigned char* sig, const 
 //verifies a DER encoded signature with given pubkey and return true if valid
 LIBBTC_API btc_bool btc_pubkey_verify_sig(const btc_pubkey* pubkey, const uint256 hash, unsigned char* sigder, int len);
 
+LIBBTC_API btc_bool btc_pubkey_getaddr_p2sh_p2wpkh(const btc_pubkey* pubkey, const btc_chainparams* chain, char *addrout);
+
+LIBBTC_API btc_bool btc_pubkey_getaddr_p2pkh(const btc_pubkey* pubkey, const btc_chainparams* chain, char *addrout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/btc/ecc_key.h
+++ b/include/btc/ecc_key.h
@@ -46,7 +46,7 @@ typedef struct btc_pubkey_ {
 } btc_pubkey;
 
 LIBBTC_API void btc_privkey_init(btc_key* privkey);
-LIBBTC_API btc_bool btc_privkey_is_valid(btc_key* privkey);
+LIBBTC_API btc_bool btc_privkey_is_valid(const btc_key* privkey);
 LIBBTC_API void btc_privkey_cleanse(btc_key* privkey);
 LIBBTC_API void btc_privkey_gen(btc_key* privkey);
 LIBBTC_API btc_bool btc_privkey_verify_pubkey(btc_key* privkey, btc_pubkey* pubkey);
@@ -56,9 +56,9 @@ LIBBTC_API void btc_privkey_encode_wif(const btc_key* privkey, const btc_chainpa
 LIBBTC_API btc_bool btc_privkey_decode_wif(const char *privkey_wif, const btc_chainparams* chain, btc_key* privkey);
 
 LIBBTC_API void btc_pubkey_init(btc_pubkey* pubkey);
-LIBBTC_API btc_bool btc_pubkey_is_valid(btc_pubkey* pubkey);
+LIBBTC_API btc_bool btc_pubkey_is_valid(const btc_pubkey* pubkey);
 LIBBTC_API void btc_pubkey_cleanse(btc_pubkey* pubkey);
-LIBBTC_API void btc_pubkey_from_key(btc_key* privkey, btc_pubkey* pubkey_inout);
+LIBBTC_API void btc_pubkey_from_key(const btc_key* privkey, btc_pubkey* pubkey_inout);
 
 //get the hash160 (single SHA256 + RIPEMD160)
 LIBBTC_API void btc_pubkey_get_hash160(const btc_pubkey* pubkey, uint160 hash160);

--- a/include/btc/memory.h
+++ b/include/btc/memory.h
@@ -52,6 +52,8 @@ LIBBTC_API void* btc_calloc(size_t count, size_t size);
 LIBBTC_API void* btc_realloc(void* ptr, size_t size);
 LIBBTC_API void btc_free(void* ptr);
 
+LIBBTC_API volatile void *btc_mem_zero(volatile void *dst, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/btc/script.h
+++ b/include/btc/script.h
@@ -205,6 +205,7 @@ enum btc_tx_out_type {
     BTC_TX_PUBKEYHASH,
     BTC_TX_SCRIPTHASH,
     BTC_TX_MULTISIG,
+    BTC_TX_WITNESS_V0_PUBKEYHASH,
 };
 
 typedef struct btc_script_op_ {
@@ -234,6 +235,8 @@ LIBBTC_API btc_bool btc_script_build_p2pkh(cstring* script, const uint160 hash16
 LIBBTC_API btc_bool btc_script_build_p2sh(cstring* script_in, const uint160 hash160);
 
 LIBBTC_API const char * btc_tx_out_type_to_str(const enum btc_tx_out_type type);
+
+LIBBTC_API btc_bool btc_script_is_witnessprogram(const cstring* script, uint8_t* version_out, uint8_t *program_out, int *programm_len_out);
 
 #ifdef __cplusplus
 }

--- a/include/btc/script.h
+++ b/include/btc/script.h
@@ -233,6 +233,8 @@ LIBBTC_API btc_bool btc_script_build_multisig(cstring* script_in, const unsigned
 LIBBTC_API btc_bool btc_script_build_p2pkh(cstring* script, const uint160 hash160);
 LIBBTC_API btc_bool btc_script_build_p2sh(cstring* script_in, const uint160 hash160);
 
+LIBBTC_API const char * btc_tx_out_type_to_str(const enum btc_tx_out_type type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/btc/script.h
+++ b/include/btc/script.h
@@ -206,6 +206,7 @@ enum btc_tx_out_type {
     BTC_TX_SCRIPTHASH,
     BTC_TX_MULTISIG,
     BTC_TX_WITNESS_V0_PUBKEYHASH,
+    BTC_TX_WITNESS_V0_SCRIPTHASH,
 };
 
 typedef struct btc_script_op_ {
@@ -232,7 +233,9 @@ LIBBTC_API void btc_script_append_pushdata(cstring* script_in, const unsigned ch
 
 LIBBTC_API btc_bool btc_script_build_multisig(cstring* script_in, const unsigned int required_signatures, const vector* pubkeys_chars);
 LIBBTC_API btc_bool btc_script_build_p2pkh(cstring* script, const uint160 hash160);
+LIBBTC_API btc_bool btc_script_build_p2wpkh(cstring* script, const uint160 hash160);
 LIBBTC_API btc_bool btc_script_build_p2sh(cstring* script_in, const uint160 hash160);
+LIBBTC_API btc_bool btc_script_get_scripthash(const cstring* script_in, uint160 scripthash);
 
 LIBBTC_API const char * btc_tx_out_type_to_str(const enum btc_tx_out_type type);
 

--- a/include/btc/tool.h
+++ b/include/btc/tool.h
@@ -38,7 +38,7 @@ extern "C" {
 #include <stdint.h>
 
 /* generate the p2pkh address from a given hex pubkey */
-LIBBTC_API btc_bool address_from_pubkey(const btc_chainparams* chain, const char* pubkey_hex, char* address);
+LIBBTC_API btc_bool addresses_from_pubkey(const btc_chainparams* chain, const char* pubkey_hex, char* pkpkh_address, char* p2sh_pkwpkh_address);
 
 /* generate the hex publickey from a given hex private key */
 LIBBTC_API btc_bool pubkey_from_privatekey(const btc_chainparams* chain, const char* privkey_hex, char* pubkey_hex, size_t* sizeout);

--- a/include/btc/tx.h
+++ b/include/btc/tx.h
@@ -112,6 +112,19 @@ LIBBTC_API btc_bool btc_tx_outpoint_is_null(btc_tx_outpoint* tx);
 LIBBTC_API btc_bool btc_tx_is_coinbase(btc_tx* tx);
 
 LIBBTC_API btc_bool btc_tx_has_witness(const btc_tx *tx);
+
+enum btc_tx_sign_result {
+    BTC_SIGN_UNKNOWN = 0,
+    BTC_SIGN_INVALID_KEY = -2,
+    BTC_SIGN_NO_KEY_MATCH = -3, //if the key found in the script doesn't match the given key, will sign anyways
+    BTC_SIGN_SIGHASH_FAILED = -4,
+    BTC_SIGN_UNKNOWN_SCRIPT_TYPE = -5,
+    BTC_SIGN_INVALID_TX_OR_SCRIPT = -6,
+    BTC_SIGN_INPUTINDEX_OUT_OF_RANGE = -7,
+    BTC_SIGN_OK = 1,
+};
+enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *script, uint64_t amount, const btc_key *privkey, int inputindex, int sighashtype, uint8_t *sigcompact_out, uint8_t *sigder_out, int *sigder_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/btc/tx.h
+++ b/include/btc/tx.h
@@ -110,6 +110,8 @@ LIBBTC_API btc_bool btc_tx_add_puzzle_out(btc_tx* tx, const int64_t amount, cons
 
 LIBBTC_API btc_bool btc_tx_outpoint_is_null(btc_tx_outpoint* tx);
 LIBBTC_API btc_bool btc_tx_is_coinbase(btc_tx* tx);
+
+LIBBTC_API btc_bool btc_tx_has_witness(const btc_tx *tx);
 #ifdef __cplusplus
 }
 #endif

--- a/include/btc/tx.h
+++ b/include/btc/tx.h
@@ -123,6 +123,7 @@ enum btc_tx_sign_result {
     BTC_SIGN_INPUTINDEX_OUT_OF_RANGE = -7,
     BTC_SIGN_OK = 1,
 };
+const char* btc_tx_sign_result_to_str(const enum btc_tx_sign_result result);
 enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *script, uint64_t amount, const btc_key *privkey, int inputindex, int sighashtype, uint8_t *sigcompact_out, uint8_t *sigder_out, int *sigder_len);
 
 #ifdef __cplusplus

--- a/src/commontools.c
+++ b/src/commontools.c
@@ -120,7 +120,9 @@ btc_bool hd_print_node(const btc_chainparams* chain, const char* nodeser)
     char privkey_wif[privkey_wif_size];
     memcpy(&pkeybase58c[1], node.private_key, BTC_ECKEY_PKEY_LENGTH);
     assert(btc_base58_encode_check(pkeybase58c, privkey_wif_size_bin, privkey_wif, privkey_wif_size) != 0);
-    printf("privatekey WIF: %s\n", privkey_wif);
+    if (btc_hdnode_has_privkey(&node)) {
+        printf("privatekey WIF: %s\n", privkey_wif);
+    }
 
     printf("depth: %d\n", node.depth);
     printf("p2pkh address: %s\n", str);

--- a/src/commontools.c
+++ b/src/commontools.c
@@ -33,26 +33,13 @@ btc_bool addresses_from_pubkey(const btc_chainparams* chain, const char* pubkey_
 
     size_t outlen = 0;
     utils_hex_to_bin(pubkey_hex, pubkey.pubkey, strlen(pubkey_hex), (int*)&outlen);
+    if (outlen != BTC_ECKEY_COMPRESSED_LENGTH) {
+        return false;
+    }
     assert(btc_pubkey_is_valid(&pubkey) == 1);
 
-    uint8_t hash160[sizeof(uint160)+1];
-    hash160[0] = chain->b58prefix_pubkey_address;
-    btc_pubkey_get_hash160(&pubkey, hash160 + 1);
-
-    btc_base58_encode_check(hash160, sizeof(hash160), pkpkh_address, 98);
-
-    // create p2sh-p2wpkh
-    cstring *p2wphk_script = cstr_new_sz(22);
-    uint160 keyhash;
-    btc_pubkey_get_hash160(&pubkey, keyhash);
-    btc_script_build_p2wpkh(p2wphk_script, keyhash);
-
-    hash160[0] = chain->b58prefix_script_address;
-    btc_script_get_scripthash(p2wphk_script, hash160+1);
-    cstr_free(p2wphk_script, true);
-
-    btc_base58_encode_check(hash160, sizeof(hash160), p2sh_pkwpkh_address, 98);
-
+    btc_pubkey_getaddr_p2pkh(&pubkey, chain, pkpkh_address);
+    btc_pubkey_getaddr_p2sh_p2wpkh(&pubkey, chain, p2sh_pkwpkh_address);
     return true;
 }
 

--- a/src/cstr.c
+++ b/src/cstr.c
@@ -83,7 +83,7 @@ cstring* cstr_new_buf(const void* buf, size_t sz)
     return s;
 }
 
-cstring* cstr_new_cstr(cstring* copy_str)
+cstring* cstr_new_cstr(const cstring* copy_str)
 {
     return cstr_new_buf(copy_str->str, copy_str->len);
 }

--- a/src/ecc_key.c
+++ b/src/ecc_key.c
@@ -53,7 +53,7 @@ btc_bool btc_privkey_is_valid(btc_key* privkey)
 
 void btc_privkey_cleanse(btc_key* privkey)
 {
-    memset(&privkey->privkey, 0, BTC_ECKEY_PKEY_LENGTH);
+    btc_mem_zero(&privkey->privkey, BTC_ECKEY_PKEY_LENGTH);
 }
 
 
@@ -105,7 +105,7 @@ void btc_pubkey_cleanse(btc_pubkey* pubkey)
     if (pubkey == NULL)
         return;
 
-    memset(pubkey->pubkey, 0, BTC_ECKEY_UNCOMPRESSED_LENGTH);
+    btc_mem_zero(pubkey->pubkey, BTC_ECKEY_UNCOMPRESSED_LENGTH);
 }
 
 

--- a/src/ecc_key.c
+++ b/src/ecc_key.c
@@ -115,7 +115,7 @@ btc_bool btc_privkey_decode_wif(const char *privkey_wif, const btc_chainparams* 
         return false;
     }
     memcpy(privkey->privkey, &privkey_data[1], BTC_ECKEY_PKEY_LENGTH);
-    btc_mem_zero(&privkey_data, strlen(privkey_wif));
+    btc_mem_zero(&privkey_data, sizeof(privkey_data));
     return true;
 }
 

--- a/src/ecc_key.c
+++ b/src/ecc_key.c
@@ -47,8 +47,11 @@ void btc_privkey_init(btc_key* privkey)
 }
 
 
-btc_bool btc_privkey_is_valid(btc_key* privkey)
+btc_bool btc_privkey_is_valid(const btc_key* privkey)
 {
+    if (!privkey) {
+        return false;
+    }
     return btc_ecc_verify_privatekey(privkey->privkey);
 }
 
@@ -126,7 +129,7 @@ void btc_pubkey_init(btc_pubkey* pubkey)
 }
 
 
-btc_bool btc_pubkey_is_valid(btc_pubkey* pubkey)
+btc_bool btc_pubkey_is_valid(const btc_pubkey* pubkey)
 {
     return btc_ecc_verify_pubkey(pubkey->pubkey, pubkey->compressed);
 }
@@ -160,7 +163,7 @@ btc_bool btc_pubkey_get_hex(const btc_pubkey* pubkey, char* str, size_t* strsize
 }
 
 
-void btc_pubkey_from_key(btc_key* privkey, btc_pubkey* pubkey_inout)
+void btc_pubkey_from_key(const btc_key* privkey, btc_pubkey* pubkey_inout)
 {
     if (pubkey_inout == NULL || privkey == NULL)
         return;

--- a/src/memory.c
+++ b/src/memory.c
@@ -115,12 +115,12 @@ void btc_free_internal(void* ptr)
 }
 
 #ifdef HAVE_MEMSET_S
-volatile void *sd_mem_zero(volatile void *dst, size_t len)
+volatile void *btc_mem_zero(volatile void *dst, size_t len)
 {
     memset_s(dst, len, 0, len);
 }
 #else
-volatile void *sd_mem_zero(volatile void *dst, size_t len)
+volatile void *btc_mem_zero(volatile void *dst, size_t len)
 {
     volatile char *buf;
     for (buf = (volatile char *)dst;  len;  buf[--len] = 0);

--- a/src/netspv.c
+++ b/src/netspv.c
@@ -443,7 +443,9 @@ void btc_net_spv_post_cmd(btc_node *node, btc_p2p_msg_hdr *hdr, struct const_buf
             for (unsigned int i=0;i<amount_of_txs;i++)
             {
                 btc_tx* tx = btc_tx_new();
-                btc_tx_deserialize(buf->p, buf->len, tx, &consumedlength, true);
+                if (!btc_tx_deserialize(buf->p, buf->len, tx, &consumedlength, true)) {
+                    printf("Error deserializing transaction\n");
+                }
                 deser_skip(buf, consumedlength);
 
                 /* send info to possible callback */

--- a/src/script.c
+++ b/src/script.c
@@ -395,3 +395,21 @@ btc_bool btc_script_build_p2sh(cstring* script_in, const uint160 hash160)
 
     return true;
 }
+
+const char * btc_tx_out_type_to_str(const enum btc_tx_out_type type) {
+    if (type == BTC_TX_PUBKEY) {
+        return "TX_PUBKEY";
+    }
+    else if (type == BTC_TX_PUBKEYHASH) {
+        return "TX_PUBKEYHASH";
+    }
+    else if (type == BTC_TX_SCRIPTHASH) {
+        return "TX_SCRIPTHASH";
+    }
+    else if (type == BTC_TX_MULTISIG) {
+        return "TX_MULTISIG";
+    }
+    else {
+        return "TX_NONSTANDARD";
+    }
+}

--- a/src/segwit_addr.c
+++ b/src/segwit_addr.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "btc/segwit_addr.h"
+#include <btc/segwit_addr.h>
 
 uint32_t bech32_polymod_step(uint32_t pre) {
     uint8_t b = pre >> 25;
@@ -51,8 +51,13 @@ int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t dat
     uint32_t chk = 1;
     size_t i = 0;
     while (hrp[i] != 0) {
-        if (!(hrp[i] >> 5)) return 0;
-        chk = bech32_polymod_step(chk) ^ (hrp[i] >> 5);
+        int ch = hrp[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+
+        if (ch >= 'A' && ch <= 'Z') return 0;
+        chk = bech32_polymod_step(chk) ^ (ch >> 5);
         ++i;
     }
     if (i + 7 + data_len > 90) return 0;

--- a/src/tools/bitcointool.c
+++ b/src/tools/bitcointool.c
@@ -302,6 +302,10 @@ int main(int argc, char* argv[])
             enum btc_tx_sign_result res = btc_tx_sign_input(tx, script, amount, &key, inputindex, sighashtype, sigcompact, sigder_plus_hashtype, &sigderlen);
             cstr_free(script, true);
 
+            if (res != BTC_SIGN_OK) {
+                printf("!!!Sign error:%s\n", btc_tx_sign_result_to_str(res));
+            }
+
             char sigcompacthex[64*2+1] = {0};
             utils_bin_to_hex((unsigned char *)sigcompact, 64, sigcompacthex);
 

--- a/src/tx.c
+++ b/src/tx.c
@@ -54,6 +54,9 @@ void btc_tx_in_free(btc_tx_in* tx_in)
         vector_free(tx_in->witness_stack, true);
         tx_in->witness_stack = NULL;
     }
+
+    memset(tx_in, 0, sizeof(*tx_in));
+    btc_free(tx_in);
 }
 
 //callback for vector free function
@@ -64,9 +67,6 @@ void btc_tx_in_free_cb(void* data)
 
     btc_tx_in* tx_in = data;
     btc_tx_in_free(tx_in);
-
-    memset(tx_in, 0, sizeof(*tx_in));
-    btc_free(tx_in);
 }
 
 void btc_tx_in_witness_stack_free_cb(void* data)
@@ -100,6 +100,9 @@ void btc_tx_out_free(btc_tx_out* tx_out)
         cstr_free(tx_out->script_pubkey, true);
         tx_out->script_pubkey = NULL;
     }
+
+    memset(tx_out, 0, sizeof(*tx_out));
+    btc_free(tx_out);
 }
 
 
@@ -110,9 +113,6 @@ void btc_tx_out_free_cb(void* data)
 
     btc_tx_out* tx_out = data;
     btc_tx_out_free(tx_out);
-
-    memset(tx_out, 0, sizeof(*tx_out));
-    btc_free(tx_out);
 }
 
 
@@ -199,7 +199,7 @@ int btc_tx_deserialize(const unsigned char* tx_serialized, size_t inlen, btc_tx*
         btc_tx_in* tx_in = btc_tx_in_new();
 
         if (!btc_tx_in_deserialize(tx_in, &buf)) {
-            btc_free(tx_in);
+            btc_tx_in_free(tx_in);
             return false;
         } else {
             vector_add(tx->vin, tx_in);

--- a/src/tx.c
+++ b/src/tx.c
@@ -741,6 +741,31 @@ btc_bool btc_tx_is_coinbase(btc_tx* tx)
     return false;
 }
 
+const char* btc_tx_sign_result_to_str(const enum btc_tx_sign_result result) {
+    if (result == BTC_SIGN_OK) {
+        return "OK";
+    }
+    else if (result == BTC_SIGN_INVALID_TX_OR_SCRIPT) {
+        return "INVALID_TX_OR_SCRIPT";
+    }
+    else if (result == BTC_SIGN_INPUTINDEX_OUT_OF_RANGE) {
+        return "INPUTINDEX_OUT_OF_RANGE";
+    }
+    else if (result == BTC_SIGN_INVALID_KEY) {
+        return "INVALID_KEY";
+    }
+    else if (result == BTC_SIGN_NO_KEY_MATCH) {
+        return "NO_KEY_MATCH";
+    }
+    else if (result == BTC_SIGN_UNKNOWN_SCRIPT_TYPE) {
+        return "SIGN_UNKNOWN_SCRIPT_TYPE";
+    }
+    else if (result == BTC_SIGN_SIGHASH_FAILED) {
+        return "SIGHASH_FAILED";
+    }
+    return "UNKOWN";
+}
+
 enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *script, uint64_t amount, const btc_key *privkey, int inputindex, int sighashtype, uint8_t *sigcompact_out, uint8_t *sigder_out, int *sigder_len_out) {
     if (!tx_in_out || !script) {
         return BTC_SIGN_INVALID_TX_OR_SCRIPT;

--- a/src/tx.c
+++ b/src/tx.c
@@ -679,6 +679,9 @@ btc_bool btc_tx_add_address_out(btc_tx* tx, const btc_chainparams* chain, int64_
     } else if (buf[0] == chain->b58prefix_script_address) {
         btc_tx_add_p2sh_hash160_out(tx, amount, &buf[1]);
     }
+    else {
+        return false;
+    }
 
     return true;
 }

--- a/test/eckey_tests.c
+++ b/test/eckey_tests.c
@@ -97,14 +97,11 @@ void test_eckey()
     char wifstr[100];
     size_t wiflen = 100;
     btc_privkey_encode_wif(&key_wif, &btc_chainparams_main, wifstr, &wiflen);
-    printf("%s\n", wifstr);
-
 
     char wif_decode_buf[100];
     wiflen = 100;
     btc_key key_wif_decode;
     btc_privkey_decode_wif(wifstr, &btc_chainparams_main, &key_wif_decode);
-    printf("END\n");
 
     u_assert_mem_eq(key_wif_decode.privkey, key_wif.privkey, sizeof(key_wif_decode.privkey));
 }

--- a/test/eckey_tests.c
+++ b/test/eckey_tests.c
@@ -88,4 +88,23 @@ void test_eckey()
     u_assert_int_eq(r, false);
     btc_privkey_cleanse(&key);
     btc_pubkey_cleanse(&pubkey);
+
+    btc_key key_wif;
+    btc_privkey_init(&key_wif);
+    assert(btc_privkey_is_valid(&key_wif) == 0);
+    btc_privkey_gen(&key_wif);
+    assert(btc_privkey_is_valid(&key_wif) == 1);
+    char wifstr[100];
+    size_t wiflen = 100;
+    btc_privkey_encode_wif(&key_wif, &btc_chainparams_main, wifstr, &wiflen);
+    printf("%s\n", wifstr);
+
+
+    char wif_decode_buf[100];
+    wiflen = 100;
+    btc_key key_wif_decode;
+    btc_privkey_decode_wif(wifstr, &btc_chainparams_main, &key_wif_decode);
+    printf("END\n");
+
+    u_assert_mem_eq(key_wif_decode.privkey, key_wif.privkey, sizeof(key_wif_decode.privkey));
 }

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -15,7 +15,8 @@
 void test_tool()
 {
     char addr[100];
-    u_assert_int_eq(address_from_pubkey(&btc_chainparams_main, "02fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f", addr), true);
+    char addr_p2sh_p2wpkh[100];
+    u_assert_int_eq(addresses_from_pubkey(&btc_chainparams_main, "02fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f", addr, addr_p2sh_p2wpkh), true);
     u_assert_str_eq(addr, "1Nro9WkpaKm9axmcfPVp79dAJU1Gx7VmMZ");
 
     size_t pubkeylen = 100;

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -1158,8 +1158,8 @@ void test_script_parse()
     btc_tx_serialize(txser, tx, false);
     char hexbuf4[txser->len * 2 + 1];
     utils_bin_to_hex((unsigned char*)txser->str, txser->len, hexbuf4);
-
-    printf("%s\n", hexbuf4);
+    // TODO: test
+    cstr_free(txser, true);
 
     btc_tx_free(tx);
 }
@@ -1192,9 +1192,17 @@ void test_invalid_tx_deser()
     utils_hex_to_bin(txstr, tx_data, strlen(txstr), &outlen);
 
     btc_tx* tx = btc_tx_new();
-    btc_tx_deserialize(tx_data, outlen, tx, NULL, true);
-
+    u_assert_int_eq(btc_tx_deserialize(tx_data, outlen, tx, NULL, true), true);
     btc_tx_free(tx);
+
+    char failed_output[] =   "02000000000101bb3ee7f13f00b58a65f3789ff9917ae2eb2f360957ca86d4ec8068deae16f94c0000000017160014d7d7d2e56512a14b41f2b412eb33f9a2c464e407ffffffff01c0878b3b0000000017a914b1";
+    uint8_t tx_data_fo[sizeof(failed_output) / 2+1];
+    utils_hex_to_bin(failed_output, tx_data_fo, strlen(failed_output), &outlen);
+
+    btc_tx* tx_o = btc_tx_new();
+    u_assert_int_eq(btc_tx_deserialize(tx_data, outlen, tx_o, NULL, true), true);
+    btc_tx_free(tx_o);
+
 }
 
 

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -57,6 +57,7 @@ extern void test_tx_negative_version();
 extern void test_script_parse();
 extern void test_script_op_codeseperator();
 extern void test_invalid_tx_deser();
+extern void test_tx_sign();
 extern void test_eckey();
 
 #ifdef WITH_WALLET
@@ -102,6 +103,7 @@ int main()
     u_run_test(test_vector);
     u_run_test(test_tx_serialization);
     u_run_test(test_invalid_tx_deser);
+    u_run_test(test_tx_sign);
     u_run_test(test_tx_sighash);
     u_run_test(test_tx_sighash_ext);
     u_run_test(test_tx_negative_version);


### PR DESCRIPTION
Adds a new function `btc_tx_sign_input(btc_tx *tx_in_out, const cstring *script, uint64_t amount, const btc_key *privkey, int inputindex, int sighashtype, uint8_t *sigcompact_out, uint8_t *sigder_out, int *sigder_len);`
to the `btc_tx_*` space.

The function is currently capable of applying a signature to an P2PKH, P2WPKH (native SegWit) input.

Adds also a "sign" command to `bitcointool`.