### PR TITLE
Trivial: use named constants instead of literals

### DIFF
--- a/include/btc/protocol.h
+++ b/include/btc/protocol.h
@@ -64,6 +64,7 @@ static const char* BTC_MSG_PONG = "pong";
 static const char* BTC_MSG_GETDATA = "getdata";
 static const char* BTC_MSG_GETHEADERS = "getheaders";
 static const char* BTC_MSG_HEADERS = "headers";
+static const char* BTC_MSG_GETBLOCKS = "getblocks";
 static const char* BTC_MSG_BLOCK = "block";
 static const char* BTC_MSG_INV = "inv";
 static const char* BTC_MSG_TX = "tx";

--- a/src/netspv.c
+++ b/src/netspv.c
@@ -267,7 +267,7 @@ void btc_net_spv_node_request_headers_or_blocks(btc_node *node, btc_bool blocks)
     btc_p2p_msg_getheaders(blocklocators, NULL, getheader_msg);
 
     /* create p2p message */
-    cstring *p2p_msg = btc_p2p_message_new(node->nodegroup->chainparams->netmagic, (blocks ? "getblocks" : "getheaders"), getheader_msg->str, getheader_msg->len);
+    cstring *p2p_msg = btc_p2p_message_new(node->nodegroup->chainparams->netmagic, (blocks ? BTC_MSG_GETBLOCKS : BTC_MSG_GETHEADERS), getheader_msg->str, getheader_msg->len);
     cstr_free(getheader_msg, true);
 
     /* send message */


### PR DESCRIPTION
I was just browsing the code when I noticed it