### PR TITLE
Fix BEGIN_DECL/END_DECL in serialize.h

### DIFF
--- a/include/btc/serialize.h
+++ b/include/btc/serialize.h
@@ -33,7 +33,7 @@
 #include "cstr.h"
 #include "portable_endian.h"
 
-LIBBTC_END_DECL
+LIBBTC_BEGIN_DECL
 
 LIBBTC_API void ser_bytes(cstring* s, const void* p, size_t len);
 LIBBTC_API void ser_u16(cstring* s, uint16_t v_);


### PR DESCRIPTION
Introduced in #123. This made compilation fail.