### PR TITLE
sha256/sha512 bug found on FPGA running NIOS II

### DIFF
--- a/src/sha2.c
+++ b/src/sha2.c
@@ -636,7 +636,7 @@ void sha256_Final(sha2_byte digest[], SHA256_CTX* context)
             int j;
             for (j = 0; j < 8; j++) {
                 REVERSE32(context->state[j], context->state[j]);
-                *d++ = context->state[j];
+                memcpy(d++, &context->state[j], sizeof(context->state[j]));
             }
         }
 #else
@@ -943,7 +943,7 @@ void sha512_Final(sha2_byte digest[], SHA512_CTX* context)
             int j;
             for (j = 0; j < 8; j++) {
                 REVERSE64(context->state[j], context->state[j]);
-                *d++ = context->state[j];
+                memcpy(d++, &context->state[j], sizeof(context->state[j]));
             }
         }
 #else


### PR DESCRIPTION
sha256/sha512 was not correctly working on my De0-Nano FPGA running NIOS II. Narrowed it down to this line and fixed it. 