### PR TITLE
Add support for P2WSH scripts and transactions.

### DIFF
--- a/include/btc/script.h
+++ b/include/btc/script.h
@@ -234,6 +234,7 @@ LIBBTC_API btc_bool btc_script_build_multisig(cstring* script_in, const unsigned
 LIBBTC_API btc_bool btc_script_build_p2pkh(cstring* script, const uint160 hash160);
 LIBBTC_API btc_bool btc_script_build_p2wpkh(cstring* script, const uint160 hash160);
 LIBBTC_API btc_bool btc_script_build_p2sh(cstring* script_in, const uint160 hash160);
+LIBBTC_API btc_bool btc_script_build_p2wsh(cstring* script_in, const uint256 hash256);
 LIBBTC_API btc_bool btc_script_get_scripthash(const cstring* script_in, uint160 scripthash);
 
 LIBBTC_API const char * btc_tx_out_type_to_str(const enum btc_tx_out_type type);


### PR DESCRIPTION
There are three main changes in this PR:
1. Add the `btc_script_build_p2wsh()` function to mirror similar functions for other transaction types.
1. Improve support in `btc_tx_add_address_out()` for P2WSH addresses.  This also fixes a little broken logic that would return `false` for P2WPKH addresses.
1. Allow `btc_script_classify_ops()` to classify P2WPKH and P2WSH addresses more accurately than "non-standard."