### PR TITLE
fix compilation error: wallet.h on c++

### DIFF
--- a/include/btc/wallet.h
+++ b/include/btc/wallet.h
@@ -33,7 +33,7 @@
 #include "buffer.h"
 #include "tx.h"
 
-LIBBTC_END_DECL
+LIBBTC_BEGIN_DECL
 
 /** single key/value record */
 typedef struct btc_wallet {


### PR DESCRIPTION
fixes a typo causing a compilation error with c++

note: test failures of new pull requests are likely related to a build system change