### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - depends/built
   - depends/sdk-sources
-  - $HOME/Library/Caches/Homebrew
+#  - $HOME/Library/Caches/Homebrew
 
 addons:
   apt:
@@ -17,8 +17,8 @@ addons:
         - wine1.6
         - libevent-dev
 
-before_install:
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew install valgrind gnu-sed --default-names; fi
+#before_install:
+#  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew install valgrind gnu-sed --default-names; fi
 
 matrix:
     fast_finish:
@@ -32,7 +32,7 @@ matrix:
         env: RUN_TOOLTESTS="yes" $BUILD_CONFIG=""
       - os: linux
         compiler: gcc
-        env: VALGRIND_UNIT_TESTS="yes" RUN_TOOLTESTS="yes" SUBMIT_COVERALLS="yes" $BUILD_CONFIG=''
+        env: VALGRIND_UNIT_TESTS="yes" RUN_TOOLTESTS="yes" VALGRIND_TOOLTESTS="yes" SUBMIT_COVERALLS="yes" $BUILD_CONFIG=''
       - os: linux
         compiler: x86_64-w64-mingw32
         env: HOST="x86_64-w64-mingw32" CROSS_COMPILE="yes" RUN_WINE_UNIT_TESTS="yes" $BUILD_CONFIG="--disable-shared --enable-static --disable-net"

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
           fi
       fi
     - if ( [ "$RUN_WINE_UNIT_TESTS" == "yes" ] ); then
-          wine /home/travis/build/libbtc/libbtc/tests.exe;
+          wine $(pwd)/tests.exe;
       fi
     - if ( [ "$RUN_TOOLTESTS" == "yes" ] ); then
           ./tooltests.py;

--- a/tooltests.py
+++ b/tooltests.py
@@ -6,7 +6,7 @@
 import sys, os
 from subprocess import call
 
-valgrind = True;
+valgrind = "VALGRIND_TOOLTESTS" in os.environ
 commands = []
 commands.append(["-v", 0])
 commands.append(["-foobar", 1])


### PR DESCRIPTION
This gets travis tests passing again, for as long as travis is still providing the service.  Valgrind's brew recipe no longer supports ox, so it is disabled on osx.  I'll let this PR sit here until the tests pass for it, in case I made an error.

Note that there are actually some valgrind failures that are not triggering ci failures, presently.  These are visible at https://travis-ci.org/github/xloem/libbtc/jobs/764476467 .

