### PR TITLE
Re-enable valgrind and check testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ script:
     - make -j2 V=1
     - ls -la
     - if ( [ "$VALGRIND_UNIT_TESTS" == "yes" ] ); then
-          valgrind --track-origins=yes --leak-check=full --error-exitcode=1 ./tests;
+          valgrind --track-origins=yes --leak-check=full --error-exitcode=1 ./tests &&
           ./tests;
       fi
     - if ( [ "$RUN_MAKE_CHECK" == "yes" ] ); then
-          make check;
-          if [ ! -f test-suite.log; ]; then
+          if ! make check; then
               cat test-suite.log;
+              false;
           fi
       fi
     - if ( [ "$RUN_WINE_UNIT_TESTS" == "yes" ] ); then

--- a/src/base58.c
+++ b/src/base58.c
@@ -240,7 +240,7 @@ int btc_base58_decode_check(const char* str, uint8_t* data, size_t datalen)
 
     size_t binsize = strl;
     if (btc_base58_decode(data, &binsize, str) != true) {
-        ret = 0;
+        return 0;
     }
 
     memmove(data, data + strl - binsize, binsize);

--- a/src/ecc_key.c
+++ b/src/ecc_key.c
@@ -124,7 +124,7 @@ btc_bool btc_privkey_decode_wif(const char *privkey_wif, const btc_chainparams* 
         return false;
     }
     memcpy(privkey->privkey, &privkey_data[1], BTC_ECKEY_PKEY_LENGTH);
-    btc_mem_zero(&privkey_data, sizeof(privkey_data));
+    btc_mem_zero(privkey_data, sizeof(privkey_data));
     btc_free(privkey_data);
     return true;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -369,8 +369,10 @@ btc_bool btc_node_group_connect_next_nodes(btc_node_group* group)
             bufferevent_enable(node->event_bev, EV_READ | EV_WRITE);
             if (bufferevent_socket_connect(node->event_bev, (struct sockaddr*)&node->addr, sizeof(node->addr)) < 0) {
                 /* Error starting connection */
-                if (node->event_bev)
+                if (node->event_bev) {
                     bufferevent_free(node->event_bev);
+                    node->event_bev = NULL;
+                }
                 return false;
             }
 

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -1189,12 +1189,12 @@ void test_script_op_codeseperator()
 void test_invalid_tx_deser()
 {
     char txstr[] =   "asadasdadad";
-    uint8_t tx_data[sizeof(txstr) / 2+1];
+    uint8_t tx_data_txstr[sizeof(txstr) / 2+1];
     int outlen;
-    utils_hex_to_bin(txstr, tx_data, strlen(txstr), &outlen);
+    utils_hex_to_bin(txstr, tx_data_txstr, strlen(txstr), &outlen);
 
     btc_tx* tx = btc_tx_new();
-    u_assert_int_eq(btc_tx_deserialize(tx_data, outlen, tx, NULL, true), false);
+    u_assert_int_eq(btc_tx_deserialize(tx_data_txstr, outlen, tx, NULL, true), false);
     btc_tx_free(tx);
 
     char failed_output[] =   "02000000000101bb3ee7f13f00b58a65f3789ff9917ae2eb2f360957ca86d4ec8068deae16f94c0000000017160014d7d7d2e56512a14b41f2b412eb33f9a2c464e407ffffffff01c0878b3b0000000017a914b1";
@@ -1202,7 +1202,7 @@ void test_invalid_tx_deser()
     utils_hex_to_bin(failed_output, tx_data_fo, strlen(failed_output), &outlen);
 
     btc_tx* tx_o = btc_tx_new();
-    u_assert_int_eq(btc_tx_deserialize(tx_data, outlen, tx_o, NULL, true), false);
+    u_assert_int_eq(btc_tx_deserialize(tx_data_fo, outlen, tx_o, NULL, true), false);
     btc_tx_free(tx_o);
 
 }

--- a/tooltests.py
+++ b/tooltests.py
@@ -42,8 +42,8 @@ commands2.append(["-t -s 5 -i 127.0.0.1:18444 0200000001554fb2f97f8fe299bf01004c
 baseCommand = "./bitcointool"
 baseCommand2 = "./bitcoin-send-tx"
 if valgrind == True:
-    baseCommand = "valgrind --leak-check=full "+baseCommand
-    baseCommand2 = "valgrind --leak-check=full "+baseCommand2
+    baseCommand = "valgrind --track-origins=yes --error-exitcode=1 --leak-check=full "+baseCommand
+    baseCommand2 = "valgrind --track-origins=yes --error-exitcode=1 --leak-check=full "+baseCommand2
 
 errored = False
 for cmd in commands:


### PR DESCRIPTION
Due to quirks of shell script evaluation, valgrind and make check errors weren't propagating failures to integration tests for a while.  This PR is to resolve that and the errors it reveals.