### PR TITLE
Additional build notes needed for README.md #95

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ The application will try to connect to max 6 peers, send the transaction two two
 How to Build
 ----------------
 
+#### Dependencies
+
+##### Debian
+```
+sudo apt-get install build-essential libevent-dev
+```
+
+##### OpenBSD
+```
+sudo pkg_add autoconf automake libtool libevent
+```
+
+##### Other
+Please submit a pull request to add dependencies for your system.
+
 #### Full library including CLI tool and wallet database
 ```
 ./autogen.sh


### PR DESCRIPTION
@ChristopherA commented on Jul 9, 2017
When I install this on a minimal Debian 8-based machine (chosen for more security as opposed to my normal Macintosh development environment) the short 3-step build instructions in the README.md are incomplete.

In my case I needed to also install some non-default development tools sudo apt-get install autoconf libtool libevent-dev. Quite possibly there are some other tools that are required but I installed previously. The README.md should probably list any toolchain dependencies.

@tomryanx commented on Aug 27, 2017
On OpenBSD, autoconf automake libtool libevent, and possibly libeventextra all need to be installed. Configure doesn't find /usr/local/include/event2/event.h by itself, either.

fixes #95