### PR TITLE
Update memory.h include line #135

### DIFF
--- a/src/bip32.c
+++ b/src/bip32.c
@@ -35,11 +35,10 @@
 #include <btc/ecc.h>
 #include <btc/ecc_key.h>
 #include <btc/hash.h>
+#include <btc/memory.h>
 #include <btc/ripemd160.h>
 #include <btc/sha2.h>
 #include <btc/utils.h>
-
-#include "memory.h"
 
 // write 4 big endian bytes
 static void write_be(uint8_t* data, uint32_t x)


### PR DESCRIPTION
fixes #135 @Andrade Include `memory.h` minor fix

`src/bip32.c` has `#include "memory.h"`. Should that be `#include <btc/memory.h>`?

https://github.com/libbtc/libbtc/blob/master/src/bip32.c#L41