### PR TITLE
Specify serial automake tests to show output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,10 +79,7 @@ script:
           ./tests;
       fi
     - if ( [ "$RUN_MAKE_CHECK" == "yes" ] ); then
-          if ! make check; then
-              cat test-suite.log;
-              false;
-          fi
+          make check;
       fi
     - if ( [ "$RUN_WINE_UNIT_TESTS" == "yes" ] ); then
           wine $(pwd)/tests.exe;

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
+AUTOMAKE_OPTIONS = serial-tests
 .PHONY: gen
 .INTERMEDIATE: $(GENBIN)
 


### PR DESCRIPTION
This might reduce user confusion, and prevents travis from terminating tests due to no output.

Since there is only one test binary, this doesn't change actual test behavior (if there were more than one test binary, it would disable parallelization).

#143