### PR TITLE
Exclude trezor-crypto from coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,5 +91,5 @@ script:
 after_success:
   - if [ "$SUBMIT_COVERALLS" == "yes" ]; then
       sudo pip install -U "cpp-coveralls";
-      coveralls --verbose -i src -x c -e src/logdb -e src/secp256k1 -r $TRAVIS_BUILD_DIR -b $TRAVIS_BUILD_DIR --gcov-options '\-lp';
+      coveralls --verbose -i src -x c -e src/logdb -e src/secp256k1 -e src/trezor-crypto -r $TRAVIS_BUILD_DIR -b $TRAVIS_BUILD_DIR --gcov-options '\-lp';
     fi


### PR DESCRIPTION
I left this out of #177. I ran into the solution replying to the windows issue.