### PR TITLE
CMake fixes and improved parity with autotools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         env: RUN_MAKE_CHECK="yes" $BUILD_CONFIG='--enable-debug'
       - os: osx
         compiler: gcc
-        env: RUN_TOOLTESTS="yes" $BUILD_CONFIG=""
+        env: RUN_TOOLTESTS="yes" CMAKE="yes" $BUILD_CONFIG=""
       - os: linux
         compiler: gcc
         env: VALGRIND_UNIT_TESTS="yes" RUN_TOOLTESTS="yes" VALGRIND_TOOLTESTS="yes" SUBMIT_COVERALLS="yes" $BUILD_CONFIG=''
@@ -67,6 +67,8 @@ before_script:
           LIBTOOL_APP_LDFLAGS='-all-static' LDFLAGS='-static' ./configure --prefix=$TRAVIS_BUILD_DIR/depends/$HOST $BUILD_CONFIG; cat config.log;
       elif [ "$SUBMIT_COVERALLS" == "yes" ]; then
           ./configure $BUILD_CONFIG CFLAGS='-fprofile-arcs -ftest-coverage'; cat config.log;
+      elif [ "$CMAKE" == "yes" ]; then
+          cmake . $BUILD_CONFIG;
       else
           ./configure $BUILD_CONFIG; cat config.log;
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,133 @@
-CMAKE_MINIMUM_REQUIRED( VERSION 3.3 )
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13) # 3.13: concise relative source paths
 
-SET( BTC_LIB_NAME  libbtc )
-PROJECT( ${BTC_LIB_NAME} )
+SET(CMAKE_C_STANDARD 99)
+SET(CMAKE_C_STANDARD_REQUIRED TRUE)
 
-add_definitions(-DUSE_NUM_GMP)
-add_definitions(-DUSE_FIELD_10X26)
-add_definitions(-DUSE_FIELD_INV_BUILTIN)
-add_definitions(-DUSE_SCALAR_8X32)
-add_definitions(-DUSE_SCALAR_INV_BUILTIN)
-add_definitions(-DRANDOM_DEVICE="/dev/urandom")
-add_definitions(-DENABLE_MODULE_RECOVERY)
+SET(LIBBTC_NAME btc)
+PROJECT(lib${LIBBTC_NAME} VERSION 0.1)
 
-FILE(GLOB SOURCES src/*.c)
-list(REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/net.c)
+INCLUDE(CTest)
+SET(USE_TESTS ${CMAKE_TESTING_ENABLED})
+SET(WITH_TOOLS TRUE CACHE BOOL "enable bitcoin tool cli application")
+SET(WITH_WALLET TRUE CACHE BOOL "enable wallet/database functions")
+SET(WITH_NET TRUE CACHE BOOL "enable net functions")
+SET(RANDOM_DEVICE "/dev/urandom" CACHE STRING "set the device to read random data from")
+IF(WITH_TOOLS OR WITH_WALLET)
+    SET(WITH_LOGDB TRUE)
+ELSE()
+    SET(WITH_LOGDB FALSE)
+ENDIF()
 
-FILE(GLOB HEADERS include/btc/*.h)
-list(REMOVE_ITEM HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/btc/net.h)
+IF(WITH_NET)
+    FIND_LIBRARY(LIBEVENT event_core REQUIRED)
+    IF(WIN32)
+        FIND_LIBRARY(LIBEVENT_PTHREADS event_pthreads REQUIRED)
+    ENDIF()
+ENDIF()
 
-FILE(GLOB LOGDB src/logdb/*.c)
+MESSAGE(STATUS "")
+MESSAGE(STATUS "Options used to compile and link:")
+MESSAGE(STATUS "  WITH_WALLET   = ${WITH_WALLET}")
+MESSAGE(STATUS "  WITH_TOOLS    = ${WITH_TOOLS}")
+MESSAGE(STATUS "  WITH_NET      = ${WITH_NET}")
+MESSAGE(STATUS "")
 
-SET(TREZOR_CRYPTO
+ADD_DEFINITIONS(
+    -DPACKAGE_NAME="${PROJECT_NAME}"
+    -DPACKAGE_VERSION="${PROJECT_VERSION}"
+    -DRANDOM_DEVICE="${RANDOM_DEVICE}"
+)
+IF(USE_TESTS)
+    ADD_DEFINITIONS(-DUSE_TESTS=1)
+ENDIF()
+IF(WITH_TOOLS)
+    ADD_DEFINITIONS(-DWITH_TOOLS=1)
+ENDIF()
+IF(WITH_WALLET)
+    ADD_DEFINITIONS(-DWITH_WALLET=1)
+ENDIF()
+IF(WITH_NET)
+    ADD_DEFINITIONS(-DWITH_NET=1)
+ENDIF()
+IF(WITH_LOGDB)
+    ADD_DEFINITIONS(-DWITH_LOGDB=1)
+ENDIF()
+FILE(TOUCH src/libbtc-config.h)
+
+
+ADD_LIBRARY(${LIBBTC_NAME})
+
+INSTALL(FILES
+    include/btc/aes256_cbc.h
+    include/btc/base58.h
+    include/btc/bip32.h
+    include/btc/block.h
+    include/btc/blockchain.h
+    include/btc/btc.h
+    include/btc/buffer.h
+    include/btc/chainparams.h
+    include/btc/cstr.h
+    include/btc/ctaes.h
+    include/btc/ecc_key.h
+    include/btc/ecc.h
+    include/btc/hash.h
+    include/btc/hmac.h
+    include/btc/memory.h
+    include/btc/portable_endian.h
+    include/btc/random.h
+    include/btc/ripemd160.h
+    include/btc/script.h
+    include/btc/segwit_addr.h
+    include/btc/serialize.h
+    include/btc/sha2.h
+    include/btc/tool.h
+    include/btc/tx.h
+    include/btc/utils.h
+    include/btc/vector.h
+    DESTINATION include/btc
+)
+
+INSTALL(FILES
+    src/trezor-crypto/base58.h
+    src/trezor-crypto/blake2_common.h
+    src/trezor-crypto/blake2b.h
+    src/trezor-crypto/blake256.h
+    src/trezor-crypto/groestl.h
+    src/trezor-crypto/groestl_internal.h
+    src/trezor-crypto/hasher.h
+    src/trezor-crypto/hmac.h
+    src/trezor-crypto/memzero.h
+    src/trezor-crypto/options.h
+    src/trezor-crypto/ripemd160.h
+    src/trezor-crypto/segwit_addr.h
+    src/trezor-crypto/sha2.h
+    src/trezor-crypto/sha3.h
+    DESTINATION include/trezor-crypto
+)
+
+TARGET_SOURCES(${LIBBTC_NAME} PRIVATE
+    src/aes256_cbc.c
+    src/base58.c
+    src/bip32.c
+    src/block.c
+    src/buffer.c
+    src/chainparams.c
+    src/commontools.c
+    src/cstr.c
+    src/ctaes.c
+    src/ecc_key.c
+    src/ecc_libsecp256k1.c
+    src/memory.c
+    src/random.c
+    src/ripemd160.c
+    src/script.c
+    src/serialize.c
+    src/tx.c
+    src/utils.c
+    src/vector.c
+)
+
+TARGET_SOURCES(${LIBBTC_NAME} PRIVATE
     src/trezor-crypto/base58.c
     src/trezor-crypto/blake2b.c
     src/trezor-crypto/blake256.c
@@ -33,19 +141,151 @@ SET(TREZOR_CRYPTO
     src/trezor-crypto/sha3.c
 )
 
-FILE(GLOB SECP256K1 src/secp256k1/src/*.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/tests.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/bench_recover.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/bench_sign.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/bench_verify.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/bench_ecdh.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/bench_internal.c)
-list(REMOVE_ITEM SECP256K1 ${CMAKE_CURRENT_SOURCE_DIR}/src/secp256k1/src/bench_schnorr_verify.c)
+FILE(GLOB SECP256K1 RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    src/secp256k1/src/*.c)
+LIST(REMOVE_ITEM SECP256K1
+    src/secp256k1/src/tests.c
+    src/secp256k1/src/tests_exhaustive.c
+    src/secp256k1/src/bench_ecdh.c
+    src/secp256k1/src/bench_ecmult.c
+    src/secp256k1/src/bench_recover.c
+    src/secp256k1/src/bench_sign.c
+    src/secp256k1/src/bench_verify.c
+    src/secp256k1/src/bench_ecdh.c
+    src/secp256k1/src/bench_internal.c
+    src/secp256k1/src/bench_schnorr_verify.c
+    src/secp256k1/src/valgrind_ctime_test.c)
+ADD_DEFINITIONS(
+    -DUSE_NUM_GMP
+    -DUSE_FIELD_10X26
+    -DUSE_FIELD_INV_BUILTIN
+    -DUSE_SCALAR_8X32
+    -DUSE_SCALAR_INV_BUILTIN
+    -DENABLE_MODULE_RECOVERY
+    -DECMULT_WINDOW_SIZE=15
+    -DECMULT_GEN_PREC_BITS=4)
+TARGET_SOURCES(${LIBBTC_NAME} PRIVATE ${SECP256K1})
 
-INCLUDE_DIRECTORIES( include )
-INCLUDE_DIRECTORIES( src/logdb/include )
-INCLUDE_DIRECTORIES( src/secp256k1 )
-INCLUDE_DIRECTORIES( ${GMP_INSTALL_DIR}/include )
+INCLUDE_DIRECTORIES(
+    include
+    src/logdb/include
+    src/secp256k1
+    ${GMP_INSTALL_DIR}/include)
 
-ADD_LIBRARY( ${BTC_LIB_NAME} ${SOURCES} ${LOGDB} ${TREZOR_CRYPTO} ${SECP256K1} ${HEADERS})
-TARGET_LINK_LIBRARIES(${BTC_LIB_NAME})
+IF(USE_TESTS)
+    ADD_EXECUTABLE(tests)
+    TARGET_SOURCES(tests PRIVATE
+        test/aes_tests.c
+        test/base58check_tests.c
+        test/bip32_tests.c
+        test/block_tests.c
+        test/buffer_tests.c
+        test/cstr_tests.c
+        test/ecc_tests.c
+        test/eckey_tests.c
+        test/hash_tests.c
+        test/memory_tests.c
+        test/random_tests.c
+        test/serialize_tests.c
+        test/sha2_tests.c
+        test/unittester.c
+        test/tx_tests.c
+        test/utils_tests.c
+        test/vector_tests.c
+    )
+    TARGET_LINK_LIBRARIES(tests ${LIBBTC_NAME})
+    ADD_TEST(NAME ${LIBBTC_NAME}_tests COMMAND tests)
+ENDIF()
+
+IF(WITH_LOGDB)
+    TARGET_SOURCES(${LIBBTC_NAME} PRIVATE
+        src/logdb/logdb_core.c
+        src/logdb/logdb_memdb_llist.c
+        src/logdb/logdb_memdb_rbtree.c
+        src/logdb/logdb_rec.c
+        src/logdb/red_black_tree.c
+    )
+    INSTALL(FILES
+        src/logdb/include/logdb/logdb_base.h
+        src/logdb/include/logdb/logdb_core.h
+        src/logdb/include/logdb/logdb_memdb_llist.h
+        src/logdb/include/logdb/logdb_memdb_rbtree.h
+        src/logdb/include/logdb/logdb_rec.h
+        src/logdb/include/logdb/logdb.h
+        src/logdb/include/logdb/red_black_tree.h
+        DESTINATION include/logdb
+    )
+    IF(USE_TESTS)
+        TARGET_SOURCES(tests PRIVATE
+            src/logdb/test/logdb_tests.c
+            src/logdb/test/tests_red_black_tree.c
+        )
+    ENDIF()
+ENDIF()
+
+IF(WITH_WALLET)
+    INSTALL(FILES
+        include/btc/wallet.h
+        DESTINATION include/btc
+    )
+    TARGET_SOURCES(${LIBBTC_NAME} PRIVATE
+        src/wallet.c
+    )
+    IF(USE_TESTS)
+        TARGET_SOURCES(tests PRIVATE
+            test/wallet_tests.c
+        )
+    ENDIF()
+ENDIF()
+
+IF(WITH_NET)
+    INSTALL(FILES
+        include/btc/headersdb.h
+        include/btc/headersdb_file.h
+        include/btc/protocol.h
+        include/btc/net.h
+        include/btc/netspv.h
+        DESTINATION include/btc
+    )
+    TARGET_SOURCES(${LIBBTC_NAME} PRIVATE
+        src/headersdb_file.c
+        src/net.c
+        src/netspv.c
+        src/protocol.c
+    )
+
+    TARGET_LINK_LIBRARIES(${LIBBTC_NAME} ${LIBEVENT} ${LIBEVENT_PTHREADS})
+
+    IF(USE_TESTS)
+        TARGET_SOURCES(tests PRIVATE
+            test/net_tests.c
+            test/netspv_tests.c
+            test/protocol_tests.c
+        )
+    ENDIF()
+ENDIF()
+
+IF(WITH_TOOLS)
+    IF(USE_TESTS)
+        TARGET_SOURCES(tests PRIVATE
+            test/tool_tests.c
+        )
+    ENDIF()
+
+    ADD_EXECUTABLE(bitcointool src/tools/bitcointool.c)
+    INSTALL(TARGETS bitcointool RUNTIME)
+    TARGET_LINK_LIBRARIES(bitcointool ${LIBBTC_NAME})
+    TARGET_INCLUDE_DIRECTORIES(bitcointool PRIVATE src)
+
+    IF(WITH_NET)
+        ADD_EXECUTABLE(bitcoin-send-tx src/tools/bitcoin-send-tx.c)
+        INSTALL(TARGETS bitcoin-send-tx RUNTIME)
+        TARGET_LINK_LIBRARIES(bitcoin-send-tx ${LIBBTC_NAME})
+        TARGET_INCLUDE_DIRECTORIES(bitcoin-send-tx PRIVATE src)
+        ADD_EXECUTABLE(bitcoin-spv src/tools/bitcoin-spv.c)
+        INSTALL(TARGETS bitcoin-spv RUNTIME)
+        TARGET_LINK_LIBRARIES(bitcoin-spv ${LIBBTC_NAME})
+        TARGET_INCLUDE_DIRECTORIES(bitcoin-spv PRIVATE src)
+    ENDIF()
+ENDIF()
+


### PR DESCRIPTION
CMake was added in an old recently-closed PR.  This newer PR adds on to the build script added in that one.  CMake is said to make it easy to build on windows, although I have not tested this myself yet.

Previously the cmake build script had been broken by other improvements.  It is now tested on travis.  There may be additional changes needed if that test fails.