### PR TITLE
Patch secp256k1 for autotools bundling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,10 +3,9 @@ AUTOMAKE_OPTIONS = serial-tests
 .PHONY: gen
 .INTERMEDIATE: $(GENBIN)
 
-LIBSECP256K1_DIR = src/secp256k1
-DIST_SUBDIRS = $(LIBSECP256K1_DIR)
+DIST_SUBDIRS = src/secp256k1
 
-LIBSECP256K1=$(LIBSECP256K1_DIR)/libsecp256k1.la
+LIBSECP256K1=src/secp256k1/libsecp256k1.la
 
 $(LIBSECP256K1): $(wildcard src/secp256k1/src/*) $(wildcard src/secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
@@ -96,7 +95,7 @@ libbtc_la_SOURCES += \
     src/trezor-crypto/sha3.c
 
 libbtc_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include
-libbtc_la_LIBADD = $(LIBSECP256K1) -L$(abs_top_builddir)/$(LIBSECP256K1_DIR)/.libs
+libbtc_la_LIBADD = $(LIBSECP256K1)
 
 if USE_TESTS
 noinst_PROGRAMS = tests

--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
-lib_LTLIBRARIES = libsecp256k1.la
+noinst_LTLIBRARIES = libsecp256k1.la
 include_HEADERS = include/secp256k1.h
 include_HEADERS += include/secp256k1_preallocated.h
 noinst_HEADERS =
@@ -53,7 +53,7 @@ noinst_HEADERS += contrib/lax_der_privatekey_parsing.c
 
 if USE_EXTERNAL_ASM
 COMMON_LIB = libsecp256k1_common.la
-noinst_LTLIBRARIES = $(COMMON_LIB)
+noinst_LTLIBRARIES += $(COMMON_LIB)
 else
 COMMON_LIB =
 endif


### PR DESCRIPTION
By making secp256k1 a convenience library, it is automatically statically bundled, resolving linking and installation issues.

This introduces 1 commit to the secp256k1 subtree.