### PR TITLE
add submodule entry for submodule used in trezor subtree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/trezor-crypto/tests/wycheproof"]
+        path = src/trezor-crypto/tests/wycheproof
+        url = https://github.com/google/wycheproof


### PR DESCRIPTION
this is a quick fix for an error that shows when libbtc is used as a submodule in submodule-based projects