### PR TITLE
Fix for wrong derivation path handling when hd_derive function is called concurrently

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,7 +94,7 @@ libbtc_la_SOURCES += \
     src/trezor-crypto/sha2.c \
     src/trezor-crypto/sha3.c
 
-libbtc_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include
+libbtc_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include -fPIC
 libbtc_la_LIBADD = $(LIBSECP256K1)
 
 if USE_TESTS

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_PATH_TOOL(STRIP, strip)
 AM_PROG_CC_C_O
 AC_PROG_CC_C99
 
-CFLAGS="$CFLAGS -W"
+CFLAGS="$CFLAGS -W -fPIC"
 
 warn_CFLAGS="-std=gnu99 -pedantic -Wno-unused-function -Wno-long-long -Wno-overlength-strings -Werror=return-type"
 saved_CFLAGS="$CFLAGS"

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -312,6 +312,7 @@ btc_bool btc_hd_generate_key(btc_hdnode* node, const char* keypath, const uint8_
     uint64_t idx = 0;
     assert(strlens(keypath) < 1024);
     char *pch, *kp = btc_malloc(strlens(keypath) + 1);
+    char *saveptr; /* for strtok_r calls - fix for concurrent calls error*/
 
     if (!kp) {
         return false;
@@ -339,7 +340,7 @@ btc_bool btc_hd_generate_key(btc_hdnode* node, const char* keypath, const uint8_
         btc_hdnode_fill_public_key(node);
     }
 
-    pch = strtok(kp + 2, delim);
+    pch = strtok_r(kp + 2, delim, &saveptr);
     while (pch != NULL) {
         size_t i = 0;
         int prm = 0;
@@ -368,7 +369,7 @@ btc_bool btc_hd_generate_key(btc_hdnode* node, const char* keypath, const uint8_
                 goto err;
             }
         }
-        pch = strtok(NULL, delim);
+        pch = strtok_r(NULL, delim, &saveptr);
     }
     btc_free(kp);
     return true;

--- a/src/trezor-crypto/hmac.c
+++ b/src/trezor-crypto/hmac.c
@@ -29,7 +29,7 @@
 
 void hmac_sha256_Init(HMAC_SHA256_CTX *hctx, const uint8_t *key,
                       const uint32_t keylen) {
-  static CONFIDENTIAL uint8_t i_key_pad[SHA256_BLOCK_LENGTH];
+  CONFIDENTIAL uint8_t i_key_pad[SHA256_BLOCK_LENGTH];
   memzero(i_key_pad, SHA256_BLOCK_LENGTH);
   if (keylen > SHA256_BLOCK_LENGTH) {
     sha256_Raw(key, keylen, i_key_pad);
@@ -61,7 +61,7 @@ void hmac_sha256_Final(HMAC_SHA256_CTX *hctx, uint8_t *hmac) {
 
 void hmac_sha256(const uint8_t *key, const uint32_t keylen, const uint8_t *msg,
                  const uint32_t msglen, uint8_t *hmac) {
-  static CONFIDENTIAL HMAC_SHA256_CTX hctx;
+  CONFIDENTIAL HMAC_SHA256_CTX hctx;
   hmac_sha256_Init(&hctx, key, keylen);
   hmac_sha256_Update(&hctx, msg, msglen);
   hmac_sha256_Final(&hctx, hmac);
@@ -69,11 +69,11 @@ void hmac_sha256(const uint8_t *key, const uint32_t keylen, const uint8_t *msg,
 
 void hmac_sha256_prepare(const uint8_t *key, const uint32_t keylen,
                          uint32_t *opad_digest, uint32_t *ipad_digest) {
-  static CONFIDENTIAL uint32_t key_pad[SHA256_BLOCK_LENGTH / sizeof(uint32_t)];
+  CONFIDENTIAL uint32_t key_pad[SHA256_BLOCK_LENGTH / sizeof(uint32_t)];
 
   memzero(key_pad, sizeof(key_pad));
   if (keylen > SHA256_BLOCK_LENGTH) {
-    static CONFIDENTIAL SHA256_CTX context;
+    CONFIDENTIAL SHA256_CTX context;
     sha256_Init(&context);
     sha256_Update(&context, key, keylen);
     sha256_Final(&context, (uint8_t *)key_pad);
@@ -103,7 +103,7 @@ void hmac_sha256_prepare(const uint8_t *key, const uint32_t keylen,
 
 void hmac_sha512_Init(HMAC_SHA512_CTX *hctx, const uint8_t *key,
                       const uint32_t keylen) {
-  static CONFIDENTIAL uint8_t i_key_pad[SHA512_BLOCK_LENGTH];
+  CONFIDENTIAL uint8_t i_key_pad[SHA512_BLOCK_LENGTH];
   memzero(i_key_pad, SHA512_BLOCK_LENGTH);
   if (keylen > SHA512_BLOCK_LENGTH) {
     sha512_Raw(key, keylen, i_key_pad);
@@ -143,11 +143,11 @@ void hmac_sha512(const uint8_t *key, const uint32_t keylen, const uint8_t *msg,
 
 void hmac_sha512_prepare(const uint8_t *key, const uint32_t keylen,
                          uint64_t *opad_digest, uint64_t *ipad_digest) {
-  static CONFIDENTIAL uint64_t key_pad[SHA512_BLOCK_LENGTH / sizeof(uint64_t)];
+  CONFIDENTIAL uint64_t key_pad[SHA512_BLOCK_LENGTH / sizeof(uint64_t)];
 
   memzero(key_pad, sizeof(key_pad));
   if (keylen > SHA512_BLOCK_LENGTH) {
-    static CONFIDENTIAL SHA512_CTX context;
+    CONFIDENTIAL SHA512_CTX context;
     sha512_Init(&context);
     sha512_Update(&context, key, keylen);
     sha512_Final(&context, (uint8_t *)key_pad);


### PR DESCRIPTION
the standard C library strtok function is not thread safe, therefore was replaced by strtok_r function