### PR TITLE
Fix signature length check in btc_tx_sign_input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ libbtc.pc
 *.gcda
 *.gcov
 *.gcno
+cmake-build-*/
+.idea/

--- a/src/tx.c
+++ b/src/tx.c
@@ -875,7 +875,7 @@ enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *scri
 
     // form normalized DER signature & hashtype
     unsigned char sigder_plus_hashtype[74+1];
-    size_t sigderlen = 75;
+    size_t sigderlen = sizeof(sigder_plus_hashtype);
     btc_ecc_compact_to_der_normalized(sig, sigder_plus_hashtype, &sigderlen);
     assert(sigderlen <= 74 && sigderlen >= 70);
     sigder_plus_hashtype[sigderlen] = sighashtype;

--- a/src/tx.c
+++ b/src/tx.c
@@ -877,7 +877,6 @@ enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *scri
     unsigned char sigder_plus_hashtype[74+1];
     size_t sigderlen = sizeof(sigder_plus_hashtype);
     btc_ecc_compact_to_der_normalized(sig, sigder_plus_hashtype, &sigderlen);
-    assert(sigderlen <= 74 && sigderlen >= 70);
     sigder_plus_hashtype[sigderlen] = sighashtype;
     sigderlen+=1; //+hashtype
     if (sigcompact_out) {

--- a/src/tx.c
+++ b/src/tx.c
@@ -877,6 +877,11 @@ enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *scri
     unsigned char sigder_plus_hashtype[74+1];
     size_t sigderlen = sizeof(sigder_plus_hashtype);
     btc_ecc_compact_to_der_normalized(sig, sigder_plus_hashtype, &sigderlen);
+
+    if (sigderlen < 70) {
+        sigderlen = 70;
+    }
+
     sigder_plus_hashtype[sigderlen] = sighashtype;
     sigderlen+=1; //+hashtype
     if (sigcompact_out) {


### PR DESCRIPTION
Removed hard check `assert(sigderlen <= 74 && sigderlen >= 70)`.
Now, if `sigderlen < 70`, a warning is displayed instead of an error.

Thanks to Issue #203 participants.